### PR TITLE
Feature/automatic forcecommand

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,6 @@ Vagrant::configure("2") do |config|
 
   $install_puppet_modules = <<SCRIPT
   puppet module list | grep -q puppetlabs-apt || puppet module install puppetlabs/apt
-  puppet module list | grep -q saz-ssh || puppet module install saz/ssh
   puppet module list | grep -q garethr-docker || puppet module install garethr/docker
 SCRIPT
 
@@ -27,6 +26,8 @@ SCRIPT
   config.vm.provision "shell", inline: "rm -rf /var/tmux"
 
   config.vm.provision :puppet do |puppet|
+    # Useful debugging options:
+    # puppet.options = "--verbose --debug --trace"
     puppet.manifests_path = 'puppet/manifests'
     puppet.manifest_file = 'site.pp'
     puppet.module_path = 'puppet/modules'

--- a/puppet/modules/accounts/manifests/init.pp
+++ b/puppet/modules/accounts/manifests/init.pp
@@ -9,29 +9,25 @@ class accounts {
     $user = $name
     
     user { $user:
-      ensure => present,
+      ensure   => present,
       # At the moment the password for each user is "vagrant". Obtain a different password by
       # running mkpasswd -m sha-512 <password> and pasting the output below.
       password => '$6$qQRxhiaIGy$8KHW4c7KEB3iOLZJRK/LVxybes7Ds3WYg6ymBe6fHh.8VUTnFOQfxUr/zYTQjvlgdL2Go5wNZRjXLn2y5VE7x0',
-      groups => ['docker'],
-      home => '/tmp',
-      shell => "/bin/bash",
+      groups   => ['docker'],
+      home     => '/tmp',
+      shell    => "/bin/bash",
     }
   }
 
   create_user { $tmux_users:; }
   
-  # TODO: Find a way to get the users defined by $tmux_users above instead of hardcoding below
   class { 'ssh::server':
     storeconfigs_enabled => false,
     options => {
-      'Match User alice' => { 'ForceCommand' => '/home/vagrant/tmux-session-for-user.sh' },
-      'Match User bob' => { 'ForceCommand' => '/home/vagrant/tmux-session-for-user.sh' },
-
-      'PasswordAuthentication'          => 'yes',
-      'PermitRootLogin'                 => 'without-password',
-      'Port'                            => [22],
-      'PubkeyAuthentication'            => 'yes',
+      'PasswordAuthentication' => 'yes',
+      'PermitRootLogin'        => 'without-password',
+      'Port'                   => [22],
+      'PubkeyAuthentication'   => 'yes'
     }
   }
 }

--- a/puppet/modules/ssh/.fixtures.yml
+++ b/puppet/modules/ssh/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  repositories:
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
+  symlinks:
+    ssh: "#{source_dir}"

--- a/puppet/modules/ssh/.gemfile
+++ b/puppet/modules/ssh/.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.1.0', :require => false
+gem 'puppet-lint', '>= 0.3.2'
+gem 'facter', '>= 1.7.0', "< 1.8.0"
+
+# vim:ft=ruby

--- a/puppet/modules/ssh/.gitignore
+++ b/puppet/modules/ssh/.gitignore
@@ -1,0 +1,3 @@
+pkg/
+*.swp
+.DS_Store

--- a/puppet/modules/ssh/.travis.yml
+++ b/puppet/modules/ssh/.travis.yml
@@ -1,0 +1,38 @@
+---
+branches:
+  only:
+    - master
+language: ruby
+bundler_args: --without development
+script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+after_success:
+  - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-releng
+  - .forge-releng/publish
+rvm:
+  - 1.8.7
+  - 1.9.3
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 2.7.0"
+    - PUPPET_GEM_VERSION="~> 3.0.0"
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+  global:
+  - PUBLISHER_LOGIN=saz
+  - secure: |-
+      bMAcMOMNUgKl7mVDNc47HwT7A8s3SvVRgy4Gu49XbyQ4C/pQ/TCSVlhyvNS7AHAA5BoZcypC
+      23f69ykM4qVFGKDEi+oy6rfWXq8WVgyqA9r30Gcg95Plna5fRt/8lmbfBpa+DLRuUYhbzOXg
+      RuXT20V+nQOHDfp7fuC0EBQxIfM=
+matrix:
+  include:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 2.6.0"
+notifications:
+  email: false
+gemfile: .gemfile

--- a/puppet/modules/ssh/LICENSE
+++ b/puppet/modules/ssh/LICENSE
@@ -1,0 +1,13 @@
+   Copyright 2011 Steffen Zieger
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/puppet/modules/ssh/Modulefile
+++ b/puppet/modules/ssh/Modulefile
@@ -1,0 +1,11 @@
+name    'saz-ssh'
+version '2.3.6'
+source 'git://github.com/saz/puppet-ssh.git'
+author 'saz'
+license 'Apache License, Version 2.0'
+summary 'UNKNOWN'
+description 'Manage SSH client and server via puppet'
+project_page 'https://github.com/saz/puppet-ssh'
+
+## Add dependencies, if any:
+dependency 'puppetlabs/stdlib', '>= 2.2.1'

--- a/puppet/modules/ssh/README.markdown
+++ b/puppet/modules/ssh/README.markdown
@@ -1,0 +1,208 @@
+# puppet-ssh [![Build Status](https://secure.travis-ci.org/saz/puppet-ssh.png)](http://travis-ci.org/saz/puppet-ssh)
+
+Manage SSH client and server via Puppet
+
+### Gittip
+[![Support via Gittip](https://rawgithub.com/twolfson/gittip-badge/0.2.0/dist/gittip.png)](https://www.gittip.com/saz/)
+
+## Requirements
+* Exported resources for host keys management
+* puppetlabs/stdlib
+
+## Usage
+
+Since version 2.0.0 only non-default values are written to both,
+client and server, configuration files.
+
+Multiple occurrences of one config key (e.g. sshd should be listening on
+port 22 and 2222) should be passed as an array.
+
+```
+    options => {
+      'Port' => [22, 2222],
+    }
+```
+
+This is working for both, client and server.
+
+### Both client and server
+Host keys will be collected and distributed unless
+ `storeconfigs_enabled` is `false`.
+
+```
+    include ssh
+```
+
+or
+
+```
+    class { 'ssh':
+      storeconfigs_enabled => false,
+      server_options => {
+        'Match User www-data' => {
+          'ChrootDirectory' => '%h',
+          'ForceCommand' => 'internal-sftp',
+          'PasswordAuthentication' => 'yes',
+          'AllowTcpForwarding' => 'no',
+          'X11Forwarding' => 'no',
+        },
+        'Port' => [22, 2222, 2288],
+      },
+      client_options => {
+        'Host *.amazonaws.com' => {
+          'User' => 'ec2-user',
+        },
+      },
+    }
+```
+
+### Hiera example
+```
+ssh::storeconfigs_enabled: true,
+
+ssh::server_options:
+    Protocol: '2'
+    ListenAddress:
+        - '127.0.0.0'
+        - '%{::hostname}'
+    PasswordAuthentication: 'yes'
+    SyslogFacility: 'AUTHPRIV'
+    UsePAM: 'yes'
+    X11Forwarding: 'yes'
+
+ssh::client_options:
+    'Host *':
+        SendEnv: 'LANG LC_*'
+        ForwardX11Trusted: 'yes'
+        ServerAliveInterval: '10'
+```
+
+### Client only
+Collected host keys from servers will be written to `known_hosts` unless
+ `storeconfigs_enabled` is `false`
+
+```
+    include ssh::client
+```
+
+or
+
+```
+    class { 'ssh::client':
+      storeconfigs_enabled => false,
+      options => {
+        'Host short' => {
+          'User' => 'my-user',
+          'HostName' => 'extreme.long.and.complicated.hostname.domain.tld',
+        },
+        'Host *' => {
+          'User' => 'andromeda',
+          'UserKnownHostsFile' => '/dev/null',
+        },
+      },
+    }
+```
+
+### Server only
+Host keys will be collected for client distribution unless
+ `storeconfigs_enabled` is `false`
+
+```
+    include ssh::server
+```
+
+or
+
+```
+    class { 'ssh::server':
+      storeconfigs_enabled => false,
+      options => {
+        'Match User www-data' => {
+          'ChrootDirectory' => '%h',
+          'ForceCommand' => 'internal-sftp',
+          'PasswordAuthentication' => 'yes',
+          'AllowTcpForwarding' => 'no',
+          'X11Forwarding' => 'no',
+        },
+        'PasswordAuthentication' => 'no',
+        'PermitRootLogin'        => 'no',
+        'Port'                   => [22, 2222],
+      },
+    }
+```
+ 
+## Default options
+
+### Client
+
+```
+    'Host *'                 => {
+      'SendEnv'              => 'LANG LC_*',
+      'HashKnownHosts'       => 'yes',
+      'GSSAPIAuthentication' => 'yes',
+    }
+```
+ 
+### Server
+
+```
+    'ChallengeResponseAuthentication' => 'no',
+    'X11Forwarding'                   => 'yes',
+    'PrintMotd'                       => 'no',
+    'AcceptEnv'                       => 'LANG LC_*',
+    'Subsystem'                       => 'sftp /usr/lib/openssh/sftp-server',
+    'UsePAM'                          => 'yes',
+```
+ 
+## Overwriting default options
+Default options will be merged with options passed in.
+If an option is set both as default and via options parameter, the latter will
+will win.
+
+The following example will disable X11Forwarding, which is enabled by default:
+
+```
+    class { 'ssh::server':
+      options           => {
+        'X11Forwarding' => 'no',
+      },
+    }
+```
+
+Which will lead to the following `sshd_config` file:
+
+ ```
+# File is managed by Puppet
+
+ChallengeResponseAuthentication no
+X11Forwarding no
+PrintMotd no
+AcceptEnv LANG LC_*
+Subsystem sftp /usr/lib/openssh/sftp-server
+UsePAM yes
+PasswordAuthentication no
+```
+
+## Defining host keys for server
+You can define host keys your server will use
+
+```
+ssh::server::host_key {'ssh_host_rsa_key':
+  private_key_content => '<the private key>',
+  public_key_content  => '<the public key>',
+}
+```
+
+Alternately, you could create the host key providing the files, instead
+of the content:
+
+```
+ssh::server::host_key {'ssh_host_rsa_key':
+  private_key_source => 'puppet:///mymodule/ssh_host_rsa_key',
+  public_key_source  => 'puppet:///mymodule/ssh_host_rsa_key.pub',
+}
+```
+
+Both of these definitions will create ```/etc/ssh/ssh_host_rsa_key``` and
+```/etc/ssh/ssh_host_rsa_key.pub``` and restart sshd daemon.
+

--- a/puppet/modules/ssh/Rakefile
+++ b/puppet/modules/ssh/Rakefile
@@ -1,0 +1,18 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Run puppet in noop mode and check for syntax errors."
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end

--- a/puppet/modules/ssh/files/sshd_config
+++ b/puppet/modules/ssh/files/sshd_config
@@ -1,0 +1,77 @@
+# Package generated configuration file
+# See the sshd(8) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 768
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin yes
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+UsePAM yes

--- a/puppet/modules/ssh/lib/puppet/parser/functions/ipaddresses.rb
+++ b/puppet/modules/ssh/lib/puppet/parser/functions/ipaddresses.rb
@@ -1,0 +1,43 @@
+module Puppet::Parser::Functions
+    newfunction(:ipaddresses, :type => :rvalue, :doc => <<-EOS
+Returns all ip addresses of network interfaces (except lo) found by facter.
+EOS
+    ) do |args|
+        interfaces = lookupvar('interfaces')
+
+        # In Puppet v2.7, lookupvar returns :undefined if the variable does
+        # not exist.  In Puppet 3.x, it returns nil.
+        # See http://docs.puppetlabs.com/guides/custom_functions.html
+        return false if (interfaces.nil? || interfaces == :undefined)
+
+        result = []
+        if interfaces.count(',') > 0
+            interfaces = interfaces.split(',')
+            interfaces.each do |iface|
+                if ! iface.include?('lo')
+                    ipaddr = lookupvar("ipaddress_#{iface}")
+                    ipaddr6 = lookupvar("ipaddress6_#{iface}")
+                    if ipaddr and (ipaddr!= :undefined)
+                        result << ipaddr
+                    end
+                    if ipaddr6 and (ipaddr6!= :undefined)
+                        result << ipaddr6
+                    end
+                end
+            end
+        else
+            if ! interfaces.include?('lo')
+                ipaddr = lookupvar("ipaddress_#{interfaces}")
+                ipaddr6 = lookupvar("ipaddress6_#{interfaces}")
+                if ipaddr and (ipaddr!= :undefined)
+                    result << ipaddr
+                end
+                if ipaddr6 and (ipaddr6!= :undefined)
+                    result << ipaddr6
+                end
+            end
+        end
+
+        return result
+    end
+end

--- a/puppet/modules/ssh/manifests/client.pp
+++ b/puppet/modules/ssh/manifests/client.pp
@@ -1,0 +1,30 @@
+class ssh::client(
+  $ensure               = present,
+  $storeconfigs_enabled = true,
+  $options              = {}
+) inherits ssh::params {
+  $merged_options = merge($ssh::params::ssh_default_options, $options)
+
+  include ssh::client::install
+  include ssh::client::config
+
+  anchor { 'ssh::client::start': }
+  anchor { 'ssh::client::end': }
+
+  # Provide option to *not* use storeconfigs/puppetdb, which means not managing
+  #  hostkeys and knownhosts
+  if ($storeconfigs_enabled) {
+    include ssh::knownhosts
+
+    Anchor['ssh::client::start'] ->
+    Class['ssh::client::install'] ->
+    Class['ssh::client::config'] ->
+    Class['ssh::knownhosts'] ->
+    Anchor['ssh::client::end']
+  } else {
+    Anchor['ssh::client::start'] ->
+    Class['ssh::client::install'] ->
+    Class['ssh::client::config'] ->
+    Anchor['ssh::client::end']
+  }
+}

--- a/puppet/modules/ssh/manifests/client/config.pp
+++ b/puppet/modules/ssh/manifests/client/config.pp
@@ -1,0 +1,15 @@
+class ssh::client::config {
+  file { $ssh::params::ssh_config:
+    ensure  => present,
+    owner   => 0,
+    group   => 0,
+    content => template("${module_name}/ssh_config.erb"),
+    require => Class['ssh::client::install'],
+  }
+
+  # Workaround for http://projects.reductivelabs.com/issues/2014
+  file { $ssh::params::ssh_known_hosts:
+    ensure => present,
+    mode   => '0644',
+  }
+}

--- a/puppet/modules/ssh/manifests/client/install.pp
+++ b/puppet/modules/ssh/manifests/client/install.pp
@@ -1,0 +1,9 @@
+class ssh::client::install {
+  if $ssh::params::client_package_name {
+    if !defined(Package[$ssh::params::client_package_name]) {
+      package { $ssh::params::client_package_name:
+        ensure => $ssh::client::ensure,
+      }
+    }
+  }
+}

--- a/puppet/modules/ssh/manifests/hostkeys.pp
+++ b/puppet/modules/ssh/manifests/hostkeys.pp
@@ -1,0 +1,26 @@
+class ssh::hostkeys {
+  $ipaddresses = ipaddresses()
+  $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
+
+  if $::sshdsakey {
+    @@sshkey { "${::fqdn}_dsa":
+      host_aliases => $host_aliases,
+      type         => dsa,
+      key          => $::sshdsakey,
+    }
+  }
+  if $::sshrsakey {
+    @@sshkey { "${::fqdn}_rsa":
+      host_aliases => $host_aliases,
+      type         => rsa,
+      key          => $::sshrsakey,
+    }
+  }
+  if $::sshecdsakey {
+    @@sshkey { "${::fqdn}_ecdsa":
+      host_aliases => $host_aliases,
+      type         => 'ecdsa-sha2-nistp256',
+      key          => $::sshecdsakey,
+    }
+  }
+}

--- a/puppet/modules/ssh/manifests/init.pp
+++ b/puppet/modules/ssh/manifests/init.pp
@@ -1,0 +1,15 @@
+class ssh (
+  $server_options       = {},
+  $client_options       = {},
+  $storeconfigs_enabled = true
+) inherits ssh::params {
+  class { 'ssh::server':
+    storeconfigs_enabled => $storeconfigs_enabled,
+    options              => $server_options,
+  }
+
+  class { 'ssh::client':
+    storeconfigs_enabled => $storeconfigs_enabled,
+    options              => $client_options,
+  }
+}

--- a/puppet/modules/ssh/manifests/knownhosts.pp
+++ b/puppet/modules/ssh/manifests/knownhosts.pp
@@ -1,0 +1,5 @@
+class ssh::knownhosts {
+  Sshkey <<| |>> {
+    ensure => present,
+  }
+}

--- a/puppet/modules/ssh/manifests/params.pp
+++ b/puppet/modules/ssh/manifests/params.pp
@@ -1,0 +1,98 @@
+class ssh::params {
+  case $::osfamily {
+    debian: {
+      $server_package_name = 'openssh-server'
+      $client_package_name = 'openssh-client'
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      $service_name = 'ssh'
+      $sftp_server_path = '/usr/lib/openssh/sftp-server'
+    }
+    redhat: {
+      $server_package_name = 'openssh-server'
+      $client_package_name = 'openssh-clients'
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      $service_name = 'sshd'
+      $sftp_server_path = '/usr/libexec/openssh/sftp-server'
+    }
+    freebsd: {
+      $server_package_name = undef
+      $client_package_name = undef
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      $service_name = 'sshd'
+      $sftp_server_path = '/usr/lib/openssh/sftp-server'
+    }
+    Archlinux: {
+      $server_package_name = 'openssh'
+      $client_package_name = 'openssh'
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      $service_name = 'sshd.service'
+      $sftp_server_path = '/usr/lib/ssh/sftp-server'
+    }
+    Suse: {
+      $server_package_name = 'openssh'
+      $client_package_name = 'openssh'
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      case $::operatingsystem {
+        Sles: {
+          $service_name = 'sshd'
+          $sftp_server_path = '/usr/lib64/ssh/sftp-server'
+        }
+        Suse: {
+          $service_name = 'sshd.service'
+          $sftp_server_path = '/usr/lib/ssh/sftp-server'
+        }
+        default: {
+          fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
+        }
+      }
+    }
+    default: {
+      case $::operatingsystem {
+        gentoo: {
+          $server_package_name = 'openssh'
+          $client_package_name = 'openssh'
+          $sshd_dir = '/etc/ssh'
+          $sshd_config = '/etc/ssh/sshd_config'
+          $ssh_config = '/etc/ssh/ssh_config'
+          $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+          $service_name = 'sshd'
+          $sftp_server_path = '/usr/lib/misc/sftp-server'
+        }
+        default: {
+          fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
+        }
+      }
+    }
+  }
+
+  $sshd_default_options = {
+    'ChallengeResponseAuthentication' => 'no',
+    'X11Forwarding'                   => 'yes',
+    'PrintMotd'                       => 'no',
+    'AcceptEnv'                       => 'LANG LC_*',
+    'Subsystem'                       => "sftp ${sftp_server_path}",
+    'UsePAM'                          => 'yes',
+  }
+
+  $ssh_default_options = {
+    'Host *'                 => {
+      'SendEnv'              => 'LANG LC_*',
+      'HashKnownHosts'       => 'yes',
+    },
+  }
+}

--- a/puppet/modules/ssh/manifests/server.pp
+++ b/puppet/modules/ssh/manifests/server.pp
@@ -1,0 +1,35 @@
+class ssh::server(
+  $ensure               = present,
+  $storeconfigs_enabled = true,
+  $options              = {}
+) inherits ssh::params {
+  $merged_options = merge($ssh::params::sshd_default_options, $options)
+
+  include ssh::server::install
+  include ssh::server::config
+  include ssh::server::service
+
+  anchor { 'ssh::server::start': }
+  anchor { 'ssh::server::end': }
+
+  # Provide option to *not* use storeconfigs/puppetdb, which means not managing
+  #  hostkeys and knownhosts
+  if ($storeconfigs_enabled) {
+    include ssh::hostkeys
+    include ssh::knownhosts
+
+    Anchor['ssh::server::start'] ->
+    Class['ssh::server::install'] ->
+    Class['ssh::server::config'] ~>
+    Class['ssh::server::service'] ->
+    Class['ssh::hostkeys'] ->
+    Class['ssh::knownhosts'] ->
+    Anchor['ssh::server::end']
+  } else {
+    Anchor['ssh::server::start'] ->
+    Class['ssh::server::install'] ->
+    Class['ssh::server::config'] ~>
+    Class['ssh::server::service'] ->
+    Anchor['ssh::server::end']
+  }
+}

--- a/puppet/modules/ssh/manifests/server/config.pp
+++ b/puppet/modules/ssh/manifests/server/config.pp
@@ -1,0 +1,11 @@
+class ssh::server::config {
+  file { $ssh::params::sshd_config:
+    ensure  => present,
+    owner   => 0,
+    group   => 0,
+    mode    => '0600',
+    content => template("${module_name}/sshd_config.erb"),
+    require => Class['ssh::server::install'],
+    notify  => Class['ssh::server::service'],
+  }
+}

--- a/puppet/modules/ssh/manifests/server/host_key.pp
+++ b/puppet/modules/ssh/manifests/server/host_key.pp
@@ -1,0 +1,84 @@
+# == Define: ssh::server::host_key
+#
+# This module install a ssh host key in the server (basically, it is
+# a file resource but it also notifies to the ssh service)
+#
+# Important! This define does not modify any option in sshd_config, so
+# you have to manually define the HostKey option in the server options
+# if you haven't done yet.
+#
+# == Parameters
+#
+# [*ensure*]
+#   Set to 'absent' to remove host_key files
+#
+# [*public_key_source*]
+#   Sets the content of the source parameter for the public key file
+#   Note public_key_source and public_key_content are mutually exclusive.
+#
+# [*public_key_content*]
+#   Sets the content for the public key file.
+#   Note public_key_source and public_key_content are mutually exclusive.
+#
+# [*private_key_source*]
+#   Sets the content of the source parameter for the private key file
+#   Note private_key_source and private_key_content are mutually exclusive.
+#
+# [*private_key_content*]
+#   Sets the content for the private key file.
+#   Note private_key_source and private_key_content are mutually exclusive.
+#
+define ssh::server::host_key (
+  $ensure = 'present',
+  $public_key_source = '',
+  $public_key_content = '',
+  $private_key_source = '',
+  $private_key_content = '',
+) {
+  if $public_key_source == '' and $public_key_content == '' {
+    fail('You must provide either public_key_source or public_key_content parameter')
+  }
+  if $private_key_source == '' and $private_key_content == '' {
+    fail('You must provide either private_key_source or private_key_content parameter')
+  }
+
+  $manage_pub_key_content = $public_key_source ? {
+    ''      => $public_key_content,
+    default => undef,
+  }
+  $manage_pub_key_source = $public_key_source ? {
+    ''      => undef,
+    default => $public_key_source,
+  }
+
+  $manage_priv_key_content = $private_key_source ? {
+    ''      => $private_key_content,
+    default => undef,
+  }
+  $manage_priv_key_source = $private_key_source ? {
+    ''      => undef,
+    default => $private_key_source,
+  }
+
+  file {"${name}_pub":
+    ensure  => $ensure,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    path    => "${::ssh::params::sshd_dir}/${name}.pub",
+    source  => $manage_pub_key_source,
+    content => $manage_pub_key_content,
+    notify  => Class['ssh::server::service'],
+  }
+
+  file {"${name}_priv":
+    ensure  => $ensure,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0600',
+    path    => "${::ssh::params::sshd_dir}/${name}",
+    source  => $manage_priv_key_source,
+    content => $manage_priv_key_content,
+    notify  => Class['ssh::server::service'],
+  }
+}

--- a/puppet/modules/ssh/manifests/server/install.pp
+++ b/puppet/modules/ssh/manifests/server/install.pp
@@ -1,0 +1,10 @@
+class ssh::server::install {
+  include ssh::params
+  if $ssh::params::server_package_name {
+    if !defined(Package[$ssh::params::server_package_name]) {
+      package { $ssh::params::server_package_name:
+        ensure   => $ssh::server::ensure,
+      }
+    }
+  }
+}

--- a/puppet/modules/ssh/manifests/server/service.pp
+++ b/puppet/modules/ssh/manifests/server/service.pp
@@ -1,0 +1,12 @@
+class ssh::server::service {
+  include ssh::params
+  include ssh::server
+
+  service { $ssh::params::service_name:
+    ensure     => running,
+    hasstatus  => true,
+    hasrestart => true,
+    enable     => true,
+    require    => Class['ssh::server::config'],
+  }
+}

--- a/puppet/modules/ssh/metadata.json
+++ b/puppet/modules/ssh/metadata.json
@@ -1,0 +1,55 @@
+{
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat"
+    },
+    {
+      "operatingsystem": "CentOS"
+    },
+    {
+      "operatingsystem": "OracleLinux"
+    },
+    {
+      "operatingsystem": "Scientific"
+    },
+    {
+      "operatingsystem": "Debian"
+    },
+    {
+      "operatingsystem": "Ubuntu"
+    },
+    {
+      "operatingsystem": "FreeBSD"
+    },
+    {
+      "operatingsystem": "Gentoo"
+    },
+    {
+      "operatingsystem": "ArchLinux"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.2.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "name": "saz-ssh",
+  "version": "2.4.0",
+  "source": "git://github.com/saz/puppet-ssh.git",
+  "author": "saz",
+  "license": "Apache License, Version 2.0",
+  "summary": "UNKNOWN",
+  "description": "Manage SSH client and server via puppet",
+  "project_page": "https://github.com/saz/puppet-ssh",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 2.2.1"
+    }
+  ]
+}

--- a/puppet/modules/ssh/spec/classes/client_spec.rb
+++ b/puppet/modules/ssh/spec/classes/client_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'ssh::client', :type => 'class' do
+    context "On Debian with no other parameters" do
+        let :facts do
+        {
+            :osfamily => 'Debian',
+            :interfaces => 'eth0',
+            :ipaddress_eth0 => '192.168.1.1'
+        }
+        end
+        it {
+            should contain_package('openssh-client').with(:ensure => 'present')
+        }
+    end
+    context "On Debian with custom ensure" do
+        let :facts do
+        {
+            :osfamily => 'Debian',
+            :interfaces => 'eth0',
+            :ipaddress_eth0 => '192.168.1.1'
+        }
+        end
+        let :params do
+        {
+            :ensure => 'latest'
+        }
+        end
+        it {
+            should contain_package('openssh-client').with(:ensure => 'latest')
+        }
+    end
+end

--- a/puppet/modules/ssh/spec/classes/server_spec.rb
+++ b/puppet/modules/ssh/spec/classes/server_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+describe 'ssh::server' do
+    let :default_params do
+        {
+            :ensure => 'present',
+            :storeconfigs_enabled => true,
+            :options => {}
+        }
+    end
+
+    [ {},
+      {
+        :ensure => 'latest',
+        :storeconfigs_enabled => true,
+        :options => {}
+      },
+      {
+        :ensure => 'present',
+        :storeconfigs_enabled => false,
+        :options => {}
+      }
+    ].each do |param_set|
+      describe "when #{param_set == {} ? "using default" : "specifying"} class parameters" do
+        let :param_hash do
+          default_params.merge(param_set)
+        end
+
+        let :params do
+          param_set
+        end
+
+        ['Debian'].each do |osfamily|
+          let :facts do
+            {
+              :osfamily => osfamily,
+              :interfaces => 'eth0',
+              :ipaddress_eth0 => '192.168.1.1'
+            }
+          end
+
+          describe "on supported osfamily: #{osfamily}" do
+            it { should contain_class('ssh::params') }
+            it { should contain_package('openssh-server').with_ensure(param_hash[:ensure]) }
+
+            it { should contain_file('/etc/ssh/sshd_config').with(
+              'owner' => 0,
+              'group' => 0
+            )}
+
+            it { should contain_service('ssh').with(
+              'ensure' => 'running',
+              'enable' => true,
+              'hasrestart' => true,
+              'hasstatus' => true
+            )}
+
+            it 'should compile the template based on the class parameters' do
+              content = param_value(
+                subject,
+                'file',
+                '/etc/ssh/sshd_config',
+                'content'
+              )
+              expected_lines = [
+                'ChallengeResponseAuthentication no',
+                'X11Forwarding yes',
+                'PrintMotd no',
+                'AcceptEnv LANG LC_*',
+                'Subsystem sftp /usr/lib/openssh/sftp-server',
+                'UsePAM yes'
+              ]
+              (content.split("\n") & expected_lines).should =~ expected_lines
+            end
+          end
+          describe "on Arch" do
+            let :facts do
+            {
+                :osfamily => 'Archlinux',
+                :lsbdistdescription => 'Arch Linux',
+                :lsbdistid => 'Arch',
+                :operatingsystem => 'Archlinux',
+                :interfaces => 'enp4s0',
+                :ipaddress_eth0 => '192.168.1.1'
+            }
+            end
+
+            it { should contain_class('ssh::params') }
+            it { should contain_package('openssh').with(
+                :ensure => param_hash[:ensure],
+                :name => 'openssh'
+            )}
+
+            it { should contain_file('/etc/ssh/sshd_config').with(
+              'owner' => 0,
+              'group' => 0
+            )}
+
+            it { should contain_service('sshd.service').with(
+              'ensure' => 'running',
+              'enable' => true,
+              'hasrestart' => true,
+              'hasstatus' => true
+            )}
+
+            it 'should compile the template based on the class parameters' do
+              content = param_value(
+                subject,
+                'file',
+                '/etc/ssh/sshd_config',
+                'content'
+              )
+              expected_lines = [
+                'ChallengeResponseAuthentication no',
+                'X11Forwarding yes',
+                'PrintMotd no',
+                'AcceptEnv LANG LC_*',
+                'Subsystem sftp /usr/lib/ssh/sftp-server',
+                'UsePAM yes'
+              ]
+              (content.split("\n") & expected_lines).should =~ expected_lines
+            end
+          end
+        end
+      end
+    end
+end

--- a/puppet/modules/ssh/spec/spec.opts
+++ b/puppet/modules/ssh/spec/spec.opts
@@ -1,0 +1,6 @@
+--format
+s
+--colour
+--loadby
+mtime
+--backtrace

--- a/puppet/modules/ssh/spec/spec_helper.rb
+++ b/puppet/modules/ssh/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rspec-puppet'
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/puppet/modules/ssh/templates/ssh_config.erb
+++ b/puppet/modules/ssh/templates/ssh_config.erb
@@ -1,0 +1,24 @@
+# File managed by Puppet
+
+<%- scope.lookupvar('ssh::client::merged_options').sort.each do |k, v| -%>
+<%- if v.is_a?(Hash) -%>
+<%= k %>
+<%- v.sort.each do |key, value| -%>
+    <%- if value.is_a?(Array) -%>
+    <%- value.each do |a| -%>
+    <%= key %> <%= a %>
+    <%- end -%>
+    <%- else -%>
+    <%= key %> <%= value %>
+    <%- end -%>
+<%- end -%>
+<%- else -%>
+<%- if v.is_a?(Array) -%>
+<%- v.each do |a| -%>
+<%= k %> <%= a %>
+<%- end -%>
+<%- elsif v != :undef -%>
+<%= k %> <%= v %>
+<%- end -%>
+<%- end -%>
+<%- end -%>

--- a/puppet/modules/ssh/templates/sshd_config.erb
+++ b/puppet/modules/ssh/templates/sshd_config.erb
@@ -1,0 +1,48 @@
+# File is managed by Puppet
+<%- options = scope.lookupvar('ssh::server::merged_options') -%>
+<%- if addressfamily = options.delete('AddressFamily') -%>
+AddressFamily <%= addressfamily %>
+<%- end -%>
+<%- if port = options.delete('Port') -%>
+<%- if port.is_a?(Array) -%>
+<%- port.each do |p| -%>
+Port <%= p %>
+<%- end -%>
+<%- else -%>
+Port <%= port %>
+<%- end -%>
+<%- end -%>
+<%- if listen = options.delete('ListenAddress') -%>
+<%- if listen.is_a?(Array) -%>
+<%- listen.each do |l| -%>
+ListenAddress <%= l %>
+<%- end -%>
+<%- else -%>
+ListenAddress <%= listen %>
+<%- end -%>
+<%- end -%>
+
+<%- options.keys.sort_by{ |sk| (sk.to_s.downcase.include? "match") ? 'zzz' + sk.to_s : sk.to_s }.each do |k| -%>
+<%- v = options[k] -%>
+<%- if v.is_a?(Hash) -%>
+<%= k %>
+<%- v.keys.sort.each do |key| -%>
+    <%- value = v[key] -%>
+    <%- if value.is_a?(Array) -%>
+    <%- value.each do |a| -%>
+    <%= key %> <%= a %>
+    <%- end -%>
+    <%- else -%>
+    <%= key %> <%= value %>
+    <%- end -%>
+<%- end -%>
+<%- else -%>
+<%- if v.is_a?(Array) -%>
+<%- v.each do |a| -%>
+<%= k %> <%= a %>
+<%- end -%>
+<%- elsif v != :undef -%>
+<%= k %> <%= v %>
+<%- end -%>
+<%- end -%>
+<%- end -%>

--- a/puppet/modules/ssh/templates/sshd_config.erb
+++ b/puppet/modules/ssh/templates/sshd_config.erb
@@ -46,3 +46,17 @@ ListenAddress <%= listen %>
 <%- end -%>
 <%- end -%>
 <%- end -%>
+
+# The simplest way is to enumerate the 'tmux_users' var found in the 'accounts' class,
+# but this isn't recommended as this is an out of scope lookup and isn't clear or safe.
+# <%- @tmux_users.each do |user| -%>
+# Match User <%= user %>
+#   ForceCommand /home/vagrant/tmux-session-for-user.sh
+# <%- end -%>
+
+# Instead we should fully qualify the var like this, which makes it much clearer:
+# Note that pre Puppet 3, you would need to use this function instead: scope.lookupvar('::accounts::tmux_users')
+<%- scope['::accounts::tmux_users'].each do |user| -%>
+Match User <%= user %>
+    ForceCommand /home/vagrant/tmux-session-for-user.sh
+<%- end -%>

--- a/puppet/modules/ssh/tests/init.pp
+++ b/puppet/modules/ssh/tests/init.pp
@@ -1,0 +1,1 @@
+class { '::ssh::server': }

--- a/puppet/modules/ssh/tests/server.pp
+++ b/puppet/modules/ssh/tests/server.pp
@@ -1,0 +1,1 @@
+include ssh::server


### PR DESCRIPTION
Hey there, as discussed IRL, this is one option to automate the 'ForceCommand' directives for the SSHD config, by enumerating the $tmux_users array.

The downside with this approach is that the 'ssh' module depends on the 'accounts' module, and will fail unless that module is present. A better approach might be to make the 'ForceCommand' users a parameter on the 'ssh::server' class, so you could pass the users array in like this:

``` puppet
class { 'ssh::server':
    storeconfigs_enabled => false,
    forcecommand_users => $tmux_users,
    forcecommand_cmd   => '/home/vagrant/tmux-session-for-user.sh',
    options => {
      'PasswordAuthentication' => 'yes',
      'PermitRootLogin'        => 'without-password',
      'Port'                   => [22],
      'PubkeyAuthentication'   => 'yes'
    }
```

The 'forcecommand_users' attribute could then be set as an empty array by default, removing the dependency on 'accounts'.
